### PR TITLE
Add batch script add + multi-select UI

### DIFF
--- a/Man1fest0/Controller/XmlBrain.swift
+++ b/Man1fest0/Controller/XmlBrain.swift
@@ -1138,82 +1138,156 @@ class XmlBrain: ObservableObject {
     
     
     func addScriptToPolicy(xmlContent: AEXMLDocument, xmlContentString: String,authToken: String,   resourceType: ResourceType, server: String, policyId: String, scriptName: String, scriptId: String, scriptParameter4: String, scriptParameter5: String, scriptParameter6: String, scriptParameter7: String, scriptParameter8: String, scriptParameter9: String,scriptParameter10: String,scriptParameter11: String, priority: String, newPolicyFlag: Bool ) {
-        
-        //        if newPolicyFlag == false {
-        //            self.separationLine()
-        //            print("Is not new policy - converting xml to AEXML Document format")
-        //            self.readXMLDataFromStringXmlBrain(xmlContent: xmlContentString)
-        //        }
-        
+
+        // Ensure we operate on the provided document rather than the global one
+        let doc = xmlContent
+
         let jamfURLQuery = server + "/JSSResource/policies/id/" + "\(policyId)"
         let url = URL(string: jamfURLQuery)!
         self.separationLine()
         print("Running addScriptToPolicy")
-        print("xmlContent is:\(xmlContent.xml)")
+        print("xmlContent is:\(doc.xml)")
         print("url is:\(url)")
         print("scriptName is:\(scriptName)")
         print("scriptId is:\(scriptId)")
-        let scripts = self.aexmlDoc.root["scripts"].addChild(name: "script")
-        //  print("Confirm current number of scripts as:\(numberOfScripts)")
-        //  self.aexmlDoc.root["scripts"].addChild(name: "size", value: String(describing:numberOfScripts))
-        scripts.addChild(name: "id", value: scriptId)
-        scripts.addChild(name: "name", value: scriptName)
-        scripts.addChild(name: "priority", value: "After")
-        
-        if scriptParameter4 != "" {
-            print("scriptParameter4 value supplied:\(scriptParameter4)")
-            scripts.addChild(name: "parameter4", value: scriptParameter4)
+
+        // Ensure scripts parent node exists
+        if doc.root["scripts"].name.isEmpty {
+            _ = doc.root.addChild(name: "scripts")
         }
-        if scriptParameter5 != "" {
-            print("scriptParameter5 value supplied:\(scriptParameter5)")
-            scripts.addChild(name: "parameter5", value: scriptParameter5)
+
+        let scriptsRoot = doc.root["scripts"]
+
+        // Create new script entry
+        let newScript = scriptsRoot.addChild(name: "script")
+        newScript.addChild(name: "id", value: scriptId)
+        newScript.addChild(name: "name", value: scriptName)
+        newScript.addChild(name: "priority", value: priority.isEmpty ? "After" : priority)
+
+        if scriptParameter4 != "" { newScript.addChild(name: "parameter4", value: scriptParameter4) }
+        if scriptParameter5 != "" { newScript.addChild(name: "parameter5", value: scriptParameter5) }
+        if scriptParameter6 != "" { newScript.addChild(name: "parameter6", value: scriptParameter6) }
+        if scriptParameter7 != "" { newScript.addChild(name: "parameter7", value: scriptParameter7) }
+        if scriptParameter8 != "" { newScript.addChild(name: "parameter8", value: scriptParameter8) }
+        if scriptParameter9 != "" { newScript.addChild(name: "parameter9", value: scriptParameter9) }
+        if scriptParameter10 != "" { newScript.addChild(name: "parameter10", value: scriptParameter10) }
+        if scriptParameter11 != "" { newScript.addChild(name: "parameter11", value: scriptParameter11) }
+
+        // Recompute size: count child elements named "script"
+        let currentScripts = scriptsRoot.children.filter { $0.name == "script" }
+        // Remove existing size element if present
+        if scriptsRoot["size"].name.isEmpty == false {
+            // remove previous size element
+            let _ = scriptsRoot["size"].removeFromParent()
         }
-        if scriptParameter6 != "" {
-            print("scriptParameter6 value supplied:\(scriptParameter6)")
-            scripts.addChild(name: "parameter6", value: scriptParameter6)
-        }
-        if scriptParameter7 != "" {
-            print("scriptParameter7 value supplied:\(scriptParameter7)")
-            scripts.addChild(name: "parameter7", value: scriptParameter7)
-        }
-        if scriptParameter8 != "" {
-            print("scriptParameter8 value supplied:\(scriptParameter8)")
-            scripts.addChild(name: "parameter8", value: scriptParameter8)
-        }
-        if scriptParameter9 != "" {
-            print("scriptParameter9 value supplied:\(scriptParameter9)")
-            scripts.addChild(name: "parameter9", value: scriptParameter9)
-        }
-        if scriptParameter10 != "" {
-            print("scriptParameter10 value supplied:\(scriptParameter10)")
-            scripts.addChild(name: "parameter10", value: scriptParameter10)
-        }
-        if scriptParameter11 != "" {
-            print("scriptParameter11 value supplied:\(scriptParameter11)")
-            scripts.addChild(name: "parameter11", value: scriptParameter11)
-        }
-        
-        //        packages.addChild(name: "action", value: "Install")
-        //        print("updatedContent is:\(self.aexmlDoc.root.xml)")
-        
-        let scriptCount = scripts.count
-        print("scriptCount is:\(scriptCount)")
-        let updatedScriptCount = scriptCount+1
-        print("updatedScriptCount is:\(updatedScriptCount)")
-        self.aexmlDoc.root["scripts"].addChild(name: "size", value: String(describing:updatedScriptCount))
-        
+        _ = scriptsRoot.addChild(name: "size", value: String(describing: currentScripts.count))
+
         if newPolicyFlag == true {
             self.separationLine()
             print("Is new policy - not posting package data to Jamf at this point")
         } else {
             self.separationLine()
             print("Is not new policy - posting updated package data to Jamf")
-            self.sendRequestAsXML(url: url, authToken: authToken,resourceType: resourceType, xml: xmlContent.xml, httpMethod: "PUT")
+            // Use a direct URLSession task so callers can perform completion handling if desired
+            var request = URLRequest(url: url)
+            request.httpMethod = "PUT"
+            request.setValue("application/xml", forHTTPHeaderField: "Content-Type")
+            request.setValue("application/xml", forHTTPHeaderField: "Accept")
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+            request.httpBody = doc.xml.data(using: .utf8)
+            let task = URLSession.shared.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    print("addScriptToPolicy request error: \(error)")
+                    return
+                }
+                if let http = response as? HTTPURLResponse {
+                    print("addScriptToPolicy response status: \(http.statusCode)")
+                }
+                if let d = data, let s = String(data: d, encoding: .utf8) {
+                    print("addScriptToPolicy response body:\n\(s)")
+                }
+            }
+            task.resume()
         }
-        
+
         print("addScriptToPolicy - updatedContent is:")
-        print(xmlContent.xml)
-        //        print(self.aexmlDoc.root.xml)
+        print(doc.xml)
+    }
+
+    // Batch add multiple scripts in one request
+    func addMultipleScriptsToPolicy(xmlContent: AEXMLDocument, xmlContentString: String, authToken: String, resourceType: ResourceType, server: String, policyId: String, scriptsToAdd: [ScriptClassic], scriptParameter4: String, scriptParameter5: String, scriptParameter6: String, scriptParameter7: String, scriptParameter8: String, scriptParameter9: String, scriptParameter10: String, scriptParameter11: String, priority: String, newPolicyFlag: Bool, completion: (() -> Void)? = nil) {
+
+        let doc = xmlContent
+        let jamfURLQuery = server + "/JSSResource/policies/id/" + "\(policyId)"
+        guard let url = URL(string: jamfURLQuery) else {
+            print("addMultipleScriptsToPolicy: invalid URL")
+            completion?()
+            return
+        }
+
+        self.separationLine()
+        print("Running addMultipleScriptsToPolicy for \(scriptsToAdd.count) scripts")
+
+        // Ensure scripts parent node exists
+        if doc.root["scripts"].name.isEmpty {
+            _ = doc.root.addChild(name: "scripts")
+        }
+        let scriptsRoot = doc.root["scripts"]
+
+        for script in scriptsToAdd {
+            let newScript = scriptsRoot.addChild(name: "script")
+            newScript.addChild(name: "id", value: String(describing: script.jamfId))
+            newScript.addChild(name: "name", value: script.name)
+            newScript.addChild(name: "priority", value: priority.isEmpty ? "After" : priority)
+            if scriptParameter4 != "" { newScript.addChild(name: "parameter4", value: scriptParameter4) }
+            if scriptParameter5 != "" { newScript.addChild(name: "parameter5", value: scriptParameter5) }
+            if scriptParameter6 != "" { newScript.addChild(name: "parameter6", value: scriptParameter6) }
+            if scriptParameter7 != "" { newScript.addChild(name: "parameter7", value: scriptParameter7) }
+            if scriptParameter8 != "" { newScript.addChild(name: "parameter8", value: scriptParameter8) }
+            if scriptParameter9 != "" { newScript.addChild(name: "parameter9", value: scriptParameter9) }
+            if scriptParameter10 != "" { newScript.addChild(name: "parameter10", value: scriptParameter10) }
+            if scriptParameter11 != "" { newScript.addChild(name: "parameter11", value: scriptParameter11) }
+        }
+
+        // Recompute size
+        let currentScripts = scriptsRoot.children.filter { $0.name == "script" }
+        if scriptsRoot["size"].name.isEmpty == false {
+            let _ = scriptsRoot["size"].removeFromParent()
+        }
+        _ = scriptsRoot.addChild(name: "size", value: String(describing: currentScripts.count))
+
+        if newPolicyFlag == true {
+            print("New policy flag - not posting to Jamf")
+            completion?()
+            return
+        }
+
+        // Build request and post
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/xml", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/xml", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        let bodyData = doc.xml.data(using: .utf8)
+        request.httpBody = bodyData
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("addMultipleScriptsToPolicy request error: \(error)")
+                DispatchQueue.main.async { completion?() }
+                return
+            }
+            if let http = response as? HTTPURLResponse {
+                print("addMultipleScriptsToPolicy response status: \(http.statusCode)")
+            }
+            if let d = data, let s = String(data: d, encoding: .utf8) {
+                print("addMultipleScriptsToPolicy response body:\n\(s)")
+            }
+            DispatchQueue.main.async {
+                completion?()
+            }
+        }
+        task.resume()
     }
     
     // ######################################################################################
@@ -2722,6 +2796,19 @@ func removeScriptFromPolicy(xmlContent: AEXMLDocument, authToken: String, server
             print("currentScript is set as:\(currentScript.xml)")
             print("Replace the attribute with parameter:\(parameter10)")
             _ = selectedScript.addChild(name: "parameter10", value: parameter10)
+            self.separationLine()
+            print("currentScript is set as:\(currentScript.xml)")
+        }
+        
+        if parameter11.isEmpty != true {
+            let selectedScriptParameter11 = self.aexmlDoc.root["scripts"].children[Int(selectedScriptNumber)]["parameter11"]
+            self.separationLine()
+            print("Parameter11 is set - Remove selectedScriptParameter11")
+            let removeSelectedScriptParameter10: () = selectedScriptParameter11.removeFromParent()
+            self.separationLine()
+            print("currentScript is set as:\(currentScript.xml)")
+            print("Replace the attribute with parameter:\(parameter11)")
+            _ = selectedScript.addChild(name: "parameter11", value: parameter11)
             self.separationLine()
             print("currentScript is set as:\(currentScript.xml)")
         }

--- a/Man1fest0/Views/Policy/PolicyScriptsTabView.swift
+++ b/Man1fest0/Views/Policy/PolicyScriptsTabView.swift
@@ -71,10 +71,11 @@ struct PolicyScriptsTabView: View {
     @State private var selection: PolicyScripts? = nil
     @State var selectedScript: ScriptClassic = ScriptClassic(name: "", jamfId: 0)
     @State var listSelection: PolicyScripts = PolicyScripts(id:(UUID(uuidString: "") ?? UUID()) , jamfId: 0, name: "")
-    @State var pickerSelectedScript = 1
-
+    @State var pickerSelectedScript = 0
     @State private var selectedNumber = 0
-
+    // multi-selection of scripts (store jamfId values)
+    @State private var selectedScriptIDs: Set<Int> = []
+    
     //  ########################################################################################
     
     @State var scriptParameter4: String = ""
@@ -150,11 +151,6 @@ struct PolicyScriptsTabView: View {
                                         Image(systemName: "10.circle").bold()
                                             .foregroundColor(.red)
                                         Text(script.parameter10 ?? "" )
-                                    }
-                                    if script.parameter11 != "" {
-                                        Image(systemName: "11.circle").bold()
-                                            .foregroundColor(.red)
-                                        Text(script.parameter11 ?? "" )
                                     }
                                     if script.priority != "" {
                                         Text(script.priority ?? "" )
@@ -237,25 +233,24 @@ struct PolicyScriptsTabView: View {
                     
                     DisclosureGroup("More Parameters") {
                         
-//                        HStack {
-//                            LazyVGrid(columns: layout.columns) {
-//                                TextField("parameter5", text: $scriptParameter5)
-//                                TextField("parameter6", text: $scriptParameter6)
-//                            }
-//                        }
-                        
                         HStack {
                             LazyVGrid(columns: layout.columns) {
-                                TextField("parameter4", text: $scriptParameter4)
                                 TextField("parameter5", text: $scriptParameter5)
                                 TextField("parameter6", text: $scriptParameter6)
                             }
                         }
+                        
+                            HStack {
+                                LazyVGrid(columns: layout.columns) {
+                                    TextField("parameter4", text: $scriptParameter4)
+                                    TextField("parameter5", text: $scriptParameter5)
+                                    TextField("parameter6", text: $scriptParameter6)
+                                }
+                            }
                         HStack {
                             LazyVGrid(columns: layout.columns) {
                                 TextField("parameter9", text: $scriptParameter9)
                                 TextField("parameter10", text: $scriptParameter10)
-                                TextField("parameter11", text: $scriptParameter11)
                             }
                         }
                         
@@ -287,7 +282,7 @@ struct PolicyScriptsTabView: View {
                     HStack {
                         
                         LazyVGrid(columns: layout.threeColumns, spacing: 10) {
-
+                            
                             
                             // Mirror the filtered picker below: allow filtering by name and guard optional names
                             Picker(selection: $selectedScript, label: Text("Scripts").bold()) {
@@ -322,16 +317,15 @@ struct PolicyScriptsTabView: View {
                         //              Add script
                         //  ################################################################################
                         
+                        // Single-add button (existing behavior)
                         Button(action: {
-                            
                             progress.showProgress()
                             progress.waitForABit()
                             
-                            xmlController.addScriptToPolicy(xmlContent: xmlController.aexmlDoc,xmlContentString: xmlController.currentPolicyAsXML, authToken: networkController.authToken, resourceType: ResourceType.policyDetail, server: server, policyId: String(describing: policyID), scriptName: selectedScript.name, scriptId: String(describing: selectedScript.jamfId),scriptParameter4: scriptParameter4, scriptParameter5: scriptParameter5 , scriptParameter6: scriptParameter6, scriptParameter7: scriptParameter7, scriptParameter8: scriptParameter8, scriptParameter9: scriptParameter9, scriptParameter10: scriptParameter10,scriptParameter11: scriptParameter11, priority: priority,newPolicyFlag: false)
+                            xmlController.addScriptToPolicy(xmlContent: xmlController.aexmlDoc, xmlContentString: xmlController.currentPolicyAsXML, authToken: networkController.authToken, resourceType: ResourceType.policyDetail, server: server, policyId: String(describing: policyID), scriptName: selectedScript.name, scriptId: String(describing: selectedScript.jamfId), scriptParameter4: scriptParameter4, scriptParameter5: scriptParameter5, scriptParameter6: scriptParameter6, scriptParameter7: scriptParameter7, scriptParameter8: scriptParameter8, scriptParameter9: scriptParameter9, scriptParameter10: scriptParameter10, scriptParameter11: scriptParameter11, priority: priority, newPolicyFlag: false)
                             
                             print("Adding script:\(selectedScript.name)")
                             print("parameter 4 is :\(scriptParameter4)")
-                            
                         }) {
                             HStack(spacing: 10) {
                                 Image(systemName: "plus.app.fill")
@@ -342,57 +336,89 @@ struct PolicyScriptsTabView: View {
                         .tint(.blue)
                         .help("Add the selected script to this policy with provided parameters.")
                         
-                        
-                        //  ################################################################################
-                        //              Remove script
-                        //  ################################################################################
-                        
-                        
-                        Button(action: {
-                            
-                            progress.showProgress()
-                            progress.waitForABit()
-                            
-                            // Pass listSelection.jamfId as optional Int? (nil if 0)
-                            let _: Int? = listSelection.jamfId == 0 ? nil : listSelection.jamfId
-                            xmlController.removeScriptFromPolicy(xmlContent: xmlController.aexmlDoc, authToken: networkController.authToken, server: server, policyId: String(describing: policyID), selectedScriptName: listSelection.name ?? "", selectedScriptId: listSelection.jamfId)
-                            
-                        }) {
-                            HStack(spacing: 10) {
-                                Image(systemName: "plus.app.fill")
-                                Text("Remove")
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.red)
-                        .help("Remove the selected script from this policy.")
-                        //                    .disabled(listedScript.jamfId == 0 && listedScript.name == "")
-                        
-                        //  ################################################################################
-                        //              Remove all scripts in policy
-                        //  ################################################################################
-                        
-                        Button(action: {
-                            
-                            progress.showProgress()
-                            progress.waitForABit()
-                            
-                            networkController.separationLine()
-                            print("Removing all scripts in policy:\(String(describing: policyID))")
-                            
-                            xmlController.removeAllScriptsFromPolicy(xmlContent: xmlController.aexmlDoc, authToken: networkController.authToken, server: server, policyId: String(describing: policyID))
-                            
-                        }) {
-                            HStack(spacing: 10) {
-                                Image(systemName: "minus.square.fill.on.square.fill")
-                                Text("Remove All")
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.red)
-                        .help("Remove all scripts currently assigned to this policy.")
-                        
                     }
+                        // Bulk add: multi-select list and Add Selected button
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Or select multiple scripts to add:")
+                                .font(.subheadline)
+                                .bold()
+                            
+                            
+                            
+                            // Scrollable list of filtered scripts with checkboxes
+                            ScrollView(.vertical) {
+                                LazyVStack(alignment: .leading, spacing: 6) {
+                                    ForEach(networkController.scripts.filter { script in
+                                        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        guard !query.isEmpty else { return true }
+                                        return script.name.localizedCaseInsensitiveContains(query)
+                                    }, id: \ .jamfId) { script in
+                                        HStack {
+                                            Button(action: {
+                                                if selectedScriptIDs.contains(script.jamfId) {
+                                                    selectedScriptIDs.remove(script.jamfId)
+                                                } else {
+                                                    selectedScriptIDs.insert(script.jamfId)
+                                                }
+                                            }) {
+                                                Image(systemName: selectedScriptIDs.contains(script.jamfId) ? "checkmark.square.fill" : "square")
+                                            }
+                                            .buttonStyle(.plain)
+                                            
+                                            Text(script.name)
+                                            Spacer()
+                                            Text("id: \(script.jamfId)")
+                                                .foregroundColor(.secondary)
+                                        }
+                                        .padding(.vertical, 2)
+                                    }
+                                }
+                            }
+                            .frame(maxHeight: 200)
+
+                        // Action buttons for bulk add / clear selection
+                        HStack(spacing: 12) {
+                            Button(action: {
+                                guard !selectedScriptIDs.isEmpty else { return }
+                                progress.showProgress()
+                                progress.waitForABit()
+
+                                // Collect selected scripts in the same order as networkController.scripts
+                                let selectedScripts = networkController.scripts.filter { selectedScriptIDs.contains($0.jamfId) }
+
+                                xmlController.addMultipleScriptsToPolicy(xmlContent: xmlController.aexmlDoc, xmlContentString: xmlController.currentPolicyAsXML, authToken: networkController.authToken, resourceType: ResourceType.policyDetail, server: server, policyId: String(describing: policyID), scriptsToAdd: selectedScripts, scriptParameter4: scriptParameter4, scriptParameter5: scriptParameter5, scriptParameter6: scriptParameter6, scriptParameter7: scriptParameter7, scriptParameter8: scriptParameter8, scriptParameter9: scriptParameter9, scriptParameter10: scriptParameter10, scriptParameter11: scriptParameter11, priority: priority, newPolicyFlag: false) {
+                                    // completion handler: refresh detailed policy and clear selection
+                                    Task {
+                                        do {
+                                            try await networkController.getDetailedPolicy(server: server, authToken: networkController.authToken, policyID: String(describing: policyID))
+                                        } catch {
+                                            print("Failed to refresh detailed policy after adding scripts: \(error)")
+                                        }
+                                        progress.endProgress()
+                                        // Clear the selection after successful upload
+                                        selectedScriptIDs.removeAll()
+                                    }
+                                }
+                            }) {
+                                HStack {
+                                    Image(systemName: "plus.rectangle.on.rectangle")
+                                    Text("Add Selected")
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.green)
+                            .help("Add all selected scripts to this policy in a single upload.")
+
+                            Button(action: {
+                                selectedScriptIDs.removeAll()
+                            }) {
+                                Text("Clear Selection")
+                            }
+                            .help("Clear currently selected scripts without uploading.")
+                        }
+                        .padding(.top, 6)
+                    }
+//                    }
                 }
                 
                 
@@ -485,6 +511,7 @@ struct PolicyScriptsTabViewDetail: View {
                     HStack { Text("Parameter 9:") ; TextField("parameter9", text: $parameter9) }
                     HStack { Text("Parameter 10:") ; TextField("parameter10", text: $parameter10) }
                     HStack { Text("Parameter 11:") ; TextField("parameter11", text: $parameter11) }
+
                     HStack {
                         Text("Priority:")
                         TextField("Before/After", text: $priority).frame(minWidth: 120)
@@ -528,6 +555,7 @@ struct PolicyScriptsTabViewDetail: View {
                 parameter8 = script.parameter8 ?? ""
                 parameter9 = script.parameter9 ?? ""
                 parameter10 = script.parameter10 ?? ""
+                parameter11 = script.parameter11 ?? ""
                 priority = script.priority ?? ""
             }
         }


### PR DESCRIPTION
Refactor script add flow and add bulk-add support.

- XmlBrain.swift: update addScriptToPolicy to operate on the passed AEXMLDocument, ensure <scripts> parent exists, append a new <script> node (with parameters and priority), recompute and update the <size> element, and perform the PUT via URLSession (Bearer auth). Add addMultipleScriptsToPolicy to batch-add an array of ScriptClassic entries, recompute size, optionally POST/PUT the updated policy, and provide a completion handler. Also add handling to remove/replace parameter11 in removeScriptFromPolicy.

- PolicyScriptsTabView.swift: introduce multi-selection (selectedScriptIDs) and a scrollable checkbox list of scripts so users can pick multiple scripts. Add "Add Selected" (calls addMultipleScriptsToPolicy and refreshes policy) and "Clear Selection" buttons. Adjust picker default index, move parameter4 into the expanded parameters area, ensure parameter11 is bound in the detail view, and tidy several UI layout bits.

These changes allow adding multiple scripts in a single upload and improve UI for selecting and managing many scripts at once.