### PR TITLE
In prog policy search improve

### DIFF
--- a/Man1fest0.xcodeproj/project.pbxproj
+++ b/Man1fest0.xcodeproj/project.pbxproj
@@ -924,7 +924,7 @@
 				CODE_SIGN_ENTITLEMENTS = Man1fest0/Man1fest0.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.76.2;
+				CURRENT_PROJECT_VERSION = 1.77.2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Man1fest0/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -971,7 +971,7 @@
 				CODE_SIGN_ENTITLEMENTS = Man1fest0/Man1fest0.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.76.2;
+				CURRENT_PROJECT_VERSION = 1.77.2;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Man1fest0/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;

--- a/Man1fest0/Controller/XmlBrain.swift
+++ b/Man1fest0/Controller/XmlBrain.swift
@@ -31,15 +31,15 @@ class XmlBrain: ObservableObject {
     //    #################################################################################
     //    DEBUG STATUS
     //    #################################################################################
-    @State var debugStatus = true
+    var debugStatus = true
     //    #################################################################################
     
 #if os(macOS)
     
-    @State var element: XMLNode = XMLNode()
-    @State var element2: XMLNode = XMLNode()
-    @State var item: XMLNode = XMLNode()
-    @State var item2: XMLNode = XMLNode()
+    var element: XMLNode = XMLNode()
+    var element2: XMLNode = XMLNode()
+    var item: XMLNode = XMLNode()
+    var item2: XMLNode = XMLNode()
     
 #endif
     
@@ -67,20 +67,20 @@ class XmlBrain: ObservableObject {
     //    Scripts
     //    #################################################################################
     
-    @State var assignedScripts: [PolicyScripts] = []
+    @Published var assignedScripts: [PolicyScripts] = []
     @Published var assignedScriptsByNameDict: [String: String] = [:]
-    @State var assignedScriptsByNameSet = Set<String>()
-    @State var assignedScriptsArray: [String] = []
+    var assignedScriptsByNameSet = Set<String>()
+    @Published var assignedScriptsArray: [String] = []
     
-    @State var clippedScripts = Set<String>()
-    @State var unassignedScriptsSet = Set<String>()
+    var clippedScripts = Set<String>()
+    var unassignedScriptsSet = Set<String>()
     @Published var unassignedScriptsArray: [String] = []
-    @State var unassignedScriptsByNameDict: [String: String] = [:]
+    var unassignedScriptsByNameDict: [String: String] = [:]
     
-    @State var allScripts: [ScriptClassic] = []
-    @State var allScriptsByNameDict: [String: String] = [:]
-    @State var allScriptsByNameSet = Set<String>()
-    @State var totalScriptsNotUsed = 0
+    @Published var allScripts: [ScriptClassic] = []
+    var allScriptsByNameDict: [String: String] = [:]
+    var allScriptsByNameSet = Set<String>()
+    var totalScriptsNotUsed = 0
     
     //    #################################################################################
     //    Icons
@@ -2344,8 +2344,8 @@ func removeScriptFromPolicy(xmlContent: AEXMLDocument, authToken: String, server
             }
             throw JamfAPIError.badResponseCode
         }
-        self.currentPolicyAsXML = (String(data: data, encoding: .utf8)!)
         DispatchQueue.main.async {
+            self.currentPolicyAsXML = (String(data: data, encoding: .utf8)!)
             self.networkController.messageStore?.show("Policy XML loaded", level: .success, details: "Policy ID: \(policyIdString)")
         }
 //        DEBUG

--- a/Man1fest0/Views/Policy/PolicyActionsDetailTableView.swift
+++ b/Man1fest0/Views/Policy/PolicyActionsDetailTableView.swift
@@ -382,7 +382,7 @@ struct PolicyActionsDetailTableView: View {
                         }
 
                         HStack {
-                            Spacer()
+//                            Spacer()
                             Button(action: {
                                 let ids = selectedPoliciesInt.compactMap { $0 }
                                 guard !ids.isEmpty else { return }

--- a/Man1fest0/Views/Policy/PolicyDetailGeneralTabView.swift
+++ b/Man1fest0/Views/Policy/PolicyDetailGeneralTabView.swift
@@ -183,6 +183,8 @@ struct PolicyDetailGeneralTabView: View {
             // ################################################################################
             
             
+            DisclosureGroup("Icons") {
+
             // ################################################################################
             //                        Icons - picker
             // ################################################################################
@@ -247,39 +249,42 @@ struct PolicyDetailGeneralTabView: View {
                         .disabled(false)
                 }
                 //
-                //                ############################################################
-                //                Update Icon Button
-                //                ############################################################
                 
-                
-                
-                
-                HStack {
-                    Button(action: {
-                        progress.showProgress()
-                        progress.waitForABit()
-                        if let icon = selectedIcon {
-                            xmlController.updateIconBatch(selectedPoliciesInt: selectedPoliciesInt , server: server, authToken: networkController.authToken, iconFilename: String(describing: icon.name), iconID: String(describing: icon.id), iconURI: String(describing: icon.url))
-                        } else {
-                            print("No icon selected")
-                        }
-                    }) {
-                        Text("Update Icon")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.blue)
-                    .help("Apply the selected icon to the selected policies in bulk.")
-                }
-                HStack {
-                    Button(action: {
-                        progress.showProgress()
-                        progress.waitForABit()
-                        networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)                        }) {
-                            Text("Refresh Icons")
+                    
+                    //                ############################################################
+                    //                Update Icon Button
+                    //                ############################################################
+                    
+                    
+                    
+                    
+                    HStack {
+                        Button(action: {
+                            progress.showProgress()
+                            progress.waitForABit()
+                            if let icon = selectedIcon {
+                                xmlController.updateIconBatch(selectedPoliciesInt: selectedPoliciesInt , server: server, authToken: networkController.authToken, iconFilename: String(describing: icon.name), iconID: String(describing: icon.id), iconURI: String(describing: icon.url))
+                            } else {
+                                print("No icon selected")
+                            }
+                        }) {
+                            Text("Update Icon")
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.blue)
-                        .help("Refresh the icon list from the server (may take time).")
+                        .help("Apply the selected icon to the selected policies in bulk.")
+                    }
+                    HStack {
+                        Button(action: {
+                            progress.showProgress()
+                            progress.waitForABit()
+                            networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)                        }) {
+                                Text("Refresh Icons")
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.blue)
+                            .help("Refresh the icon list from the server (may take time).")
+                    }
                 }
             }
             Spacer()

--- a/Man1fest0/Views/Policy/PolicyRowView.swift
+++ b/Man1fest0/Views/Policy/PolicyRowView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 // PolicyRowView: compact row that expands to show details and has a collapsible Scripts section.
 struct PolicyRowView: View {
+    
     let policy: PolicyDetailed
 
     @State private var isExpanded: Bool = false
@@ -20,6 +21,7 @@ struct PolicyRowView: View {
     private var generalName: String { policy.general?.name ?? "(no name)" }
     private var jamfID: Int { policy.general?.jamfId ?? 0 }
     private var enabledString: String { policy.general?.enabled.map { String(describing: $0) } ?? "-" }
+    private var customTrigger: String { policy.general?.triggerOther ?? "" }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -53,9 +55,15 @@ struct PolicyRowView: View {
                                 .foregroundColor(.secondary)
                                 .lineLimit(1)
                         }
+
+                        if !customTrigger.isEmpty {
+                            Text("Trigger: \(customTrigger)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
                     }
                 }
-
                 Spacer()
             }
             .contentShape(Rectangle())

--- a/Man1fest0/Views/Policy/PolicySearchView.swift
+++ b/Man1fest0/Views/Policy/PolicySearchView.swift
@@ -238,7 +238,7 @@ struct PolicySearchView: View {
                 
                 HStack {
                     // Match mode segmented control (Contains / Starts With)
-                    Picker("Match Mode", selection: $matchMode) {
+                    Picker("Mode", selection: $matchMode) {
                         ForEach(MatchMode.allCases, id: \.self) { mode in
                             Text(mode.displayName)
                             }

--- a/Man1fest0/Views/Policy/PolicySearchView.swift
+++ b/Man1fest0/Views/Policy/PolicySearchView.swift
@@ -248,7 +248,7 @@ struct PolicySearchView: View {
                     
                     // Case sensitivity toggle
                     Toggle(isOn: $caseSensitive) {
-                        Text("Case Sensitive")
+                        Text("Case")
                     }
                     .toggleStyle(SwitchToggleStyle())
                     
@@ -406,83 +406,87 @@ struct PolicySearchView: View {
             //        }
             
             
-            // ################################################################################
-            //                        Icons - picker
-            // ################################################################################
-            
-            
-            HStack {
-              
-                ScrollView(.horizontal, showsIndicators: true) {
-                    HStack(spacing: 8) {
-                        ForEach(networkController.allIconsDetailed.filter { iconFilter.isEmpty ? true : $0.name.lowercased().contains(iconFilter.lowercased()) }) { icon in
-                            AsyncImage(url: URL(string: icon.url)) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image.resizable().scaledToFill()
-                                case .failure(_):
-                                    Image(systemName: "photo").resizable().scaledToFit()
-                                default:
-                                    ProgressView()
+            DisclosureGroup("Icons") {
+                
+                
+                // ################################################################################
+                //                        Icons - picker
+                // ################################################################################
+                
+                
+                HStack {
+                    
+                    ScrollView(.horizontal, showsIndicators: true) {
+                        HStack(spacing: 8) {
+                            ForEach(networkController.allIconsDetailed.filter { iconFilter.isEmpty ? true : $0.name.lowercased().contains(iconFilter.lowercased()) }) { icon in
+                                AsyncImage(url: URL(string: icon.url)) { phase in
+                                    switch phase {
+                                    case .success(let image):
+                                        image.resizable().scaledToFill()
+                                    case .failure(_):
+                                        Image(systemName: "photo").resizable().scaledToFit()
+                                    default:
+                                        ProgressView()
+                                    }
                                 }
+                                .frame(width: 30, height: 30)
+                                .clipShape(Circle())
+                                .overlay(Circle().stroke(selectedIcon?.id == icon.id ? Color.blue : Color.clear, lineWidth: 2))
+                                .onTapGesture {
+                                    selectedIcon = icon
+                                    selectedIconString = icon.name
+                                }
+                                .help(icon.name)
                             }
-                            .frame(width: 30, height: 30)
-                            .clipShape(Circle())
-                            .overlay(Circle().stroke(selectedIcon?.id == icon.id ? Color.blue : Color.clear, lineWidth: 2))
-                            .onTapGesture {
-                                selectedIcon = icon
-                                selectedIconString = icon.name
-                            }
-                            .help(icon.name)
                         }
+                        .padding(.vertical, 4)
                     }
-                    .padding(.vertical, 4)
+                    TextField("Filter", text: $iconFilter)
+                        .onAppear {
+                            if !networkController.allIconsDetailed.isEmpty {
+                                selectedIcon = networkController.allIconsDetailed.first
+                            } else {
+                                selectedIcon = nil
+                            }
+                        }
+                        .onChange(of: networkController.allIconsDetailed) { newIcons in
+                            if !newIcons.isEmpty { selectedIcon = newIcons.first } else { selectedIcon = nil }
+                        }
                 }
-                TextField("Filter", text: $iconFilter)
-                .onAppear {
-                    if !networkController.allIconsDetailed.isEmpty {
-                        selectedIcon = networkController.allIconsDetailed.first
-                    } else {
-                        selectedIcon = nil
+                
+                
+                //                ############################################################
+                //                Update Icon Button
+                //                ############################################################
+                
+                
+                
+                
+                HStack {
+                    Button(action: {
+                        progress.showProgress()
+                        progress.waitForABit()
+                        if let icon = selectedIcon {
+                            xmlController.updateIconBatch(selectedPoliciesInt: policiesMatchingItems , server: server, authToken: networkController.authToken, iconFilename: String(describing: icon.name), iconID: String(describing: icon.id), iconURI: String(describing: icon.url))
+                        } else {
+                            print("No icon selected")
+                        }
+                    }) {
+                        Text("Update Icon")
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.blue)
                 }
-                .onChange(of: networkController.allIconsDetailed) { newIcons in
-                    if !newIcons.isEmpty { selectedIcon = newIcons.first } else { selectedIcon = nil }
-                }
-            }
-            
-            
-            //                ############################################################
-            //                Update Icon Button
-            //                ############################################################
-                
-                
-                
-                
-            HStack {
-                Button(action: {
-                    progress.showProgress()
-                    progress.waitForABit()
-                    if let icon = selectedIcon {
-                                                xmlController.updateIconBatch(selectedPoliciesInt: policiesMatchingItems , server: server, authToken: networkController.authToken, iconFilename: String(describing: icon.name), iconID: String(describing: icon.id), iconURI: String(describing: icon.url))
-                    } else {
-                        print("No icon selected")
-                    }
-                }) {
-                    Text("Update Icon")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.blue)
-            }
-            HStack {
-                Button(action: {
-                    progress.showProgress()
-                    progress.waitForABit()
-                    networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)                        }) {
+                HStack {
+                    Button(action: {
+                        progress.showProgress()
+                        progress.waitForABit()
+                        networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)                        }) {
                             Text("Refresh Icons")
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.blue)
+                }
             }
             
             
@@ -624,6 +628,7 @@ enum SearchField: String, CaseIterable {
     case generalName
     case generalID
     case generalEnabled
+    case customTrigger
     case selfServiceDisplayName
     case selfServiceDescription
     case selfServiceIconURI
@@ -647,6 +652,7 @@ enum SearchField: String, CaseIterable {
         case .generalName: return "General: Name"
         case .generalID: return "General: ID"
         case .generalEnabled: return "General: Enabled"
+        case .customTrigger: return "General: Custom Trigger"
         case .selfServiceDisplayName: return "Self Service: Display Name"
         case .selfServiceDescription: return "Self Service: Description"
         case .selfServiceIconURI: return "Self Service: Icon URI"
@@ -699,6 +705,7 @@ enum SearchField: String, CaseIterable {
                     case .startsWith: return subject.hasPrefix(targetSearch)
                     }
                 }()) ||
+                match(policy.general?.triggerOther) ||
                 match(policy.self_service?.selfServiceDisplayName) ||
                 match(policy.self_service?.selfServiceDescription) ||
                 match(policy.self_service?.selfServiceIcon?.uri) ||
@@ -756,6 +763,8 @@ enum SearchField: String, CaseIterable {
         case .generalEnabled:
             if let enabled = policy.general?.enabled { let enabledString = String(describing: enabled); return caseSensitive ? enabledString.contains(search) : enabledString.lowercased().contains(targetSearch) }
             return false
+        case .customTrigger:
+            return match(policy.general?.triggerOther)
         case .selfServiceDisplayName:
             return match(policy.self_service?.selfServiceDisplayName)
         case .selfServiceDescription:
@@ -803,6 +812,8 @@ enum SearchField: String, CaseIterable {
             return policy.general?.jamfId == nil
         case .generalEnabled:
             return policy.general?.enabled == nil
+        case .customTrigger:
+            return (policy.general?.triggerOther?.isEmpty ?? true)
         case .selfServiceDisplayName:
             return (policy.self_service?.selfServiceDisplayName?.isEmpty ?? true)
         case .selfServiceDescription:

--- a/Man1fest0/Views/Policy/PolicySearchView.swift
+++ b/Man1fest0/Views/Policy/PolicySearchView.swift
@@ -56,7 +56,7 @@ struct PolicySearchView: View {
     
     // Bulk actions for selected policies
     @State private var selectedPoliciesForActions = Set<Int?>()
-    @State private var showActionsPanel: Bool = false
+    @State private var showActionsPanel: Bool = true
     @State private var policiesSelection = Set<Policy>()
     
     @State var policiesMatchingItems: [Int] = []
@@ -406,74 +406,6 @@ struct PolicySearchView: View {
                 if showActionsPanel {
                     PolicyDetailGeneralTabView(server: server, selectedPoliciesInt: Array(selectedPoliciesForActions), policiesSelection: $policiesSelection)
                         .frame(maxHeight: 500)
-                }
-            }
-            
-            DisclosureGroup("Icons") {
-                HStack {
-                    ScrollView(.horizontal, showsIndicators: true) {
-                        HStack(spacing: 8) {
-                            ForEach(networkController.allIconsDetailed.filter { iconFilter.isEmpty ? true : $0.name.lowercased().contains(iconFilter.lowercased()) }) { icon in
-                                AsyncImage(url: URL(string: icon.url)) { phase in
-                                    switch phase {
-                                    case .success(let image):
-                                        image.resizable().scaledToFill()
-                                    case .failure(_):
-                                        Image(systemName: "photo").resizable().scaledToFit()
-                                    default:
-                                        ProgressView()
-                                    }
-                                }
-                                .frame(width: 30, height: 30)
-                                .clipShape(Circle())
-                                .overlay(Circle().stroke(selectedIcon?.id == icon.id ? Color.blue : Color.clear, lineWidth: 2))
-                                .onTapGesture {
-                                    selectedIcon = icon
-                                    selectedIconString = icon.name
-                                }
-                                .help(icon.name)
-                            }
-                        }
-                        .padding(.vertical, 4)
-                    }
-                    TextField("Filter", text: $iconFilter)
-                        .onAppear {
-                            if !networkController.allIconsDetailed.isEmpty {
-                                selectedIcon = networkController.allIconsDetailed.first
-                            } else {
-                                selectedIcon = nil
-                            }
-                        }
-                        .onChange(of: networkController.allIconsDetailed) { newIcons in
-                            if !newIcons.isEmpty { selectedIcon = newIcons.first } else { selectedIcon = nil }
-                        }
-                }
-                
-                HStack {
-                    Button(action: {
-                        progress.showProgress()
-                        progress.waitForABit()
-                        if let icon = selectedIcon {
-                            xmlController.updateIconBatch(selectedPoliciesInt: policiesMatchingItems , server: server, authToken: networkController.authToken, iconFilename: String(describing: icon.name), iconID: String(describing: icon.id), iconURI: String(describing: icon.url))
-                        } else {
-                            print("No icon selected")
-                        }
-                    }) {
-                        Text("Update Icon")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.blue)
-                }
-                HStack {
-                    Button(action: {
-                        progress.showProgress()
-                        progress.waitForABit()
-                        networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)
-                    }) {
-                        Text("Refresh Icons")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.blue)
                 }
             }
             

--- a/Man1fest0/Views/Policy/PolicySearchView.swift
+++ b/Man1fest0/Views/Policy/PolicySearchView.swift
@@ -54,6 +54,11 @@ struct PolicySearchView: View {
     @State private var matchMode: MatchMode = .contains
     @State private var caseSensitive: Bool = false
     
+    // Bulk actions for selected policies
+    @State private var selectedPoliciesForActions = Set<Int?>()
+    @State private var showActionsPanel: Bool = false
+    @State private var policiesSelection = Set<Policy>()
+    
     @State var policiesMatchingItems: [Int] = []
     @State var policiesMissingItems: [Int] = []
     @State var policyName = ""
@@ -109,6 +114,8 @@ struct PolicySearchView: View {
         let ids = pairs.filter { $0.isHighlighted }.compactMap { $0.policy.general?.jamfId }
         policiesMatchingItems = ids
         networkController.policiesMatchingItems = ids
+        // Auto-select matching policies in the checkbox state (convert to Optional for Set<Int?>)
+        selectedPoliciesForActions = Set(ids.map { Optional($0) })
     }
 
     // Export currently-displayed search results to CSV in the user's Downloads folder.
@@ -326,11 +333,28 @@ struct PolicySearchView: View {
                     // Show only filtered (matching) policies and use the model's Identifiable id
                     ForEach(displayedPairs) { pair in
                         HStack(spacing: 8) {
+                            // Checkbox for selecting policy for actions
+                            Button(action: {
+                                let jamfId = pair.policy.general?.jamfId
+                                if selectedPoliciesForActions.contains(jamfId) {
+                                    selectedPoliciesForActions.remove(jamfId)
+                                } else {
+                                    selectedPoliciesForActions.insert(jamfId)
+                                }
+                            }) {
+                                Image(systemName: selectedPoliciesForActions.contains(pair.policy.general?.jamfId) ? "checkmark.square.fill" : "square")
+                                    .foregroundColor(selectedPoliciesForActions.contains(pair.policy.general?.jamfId) ? .blue : .secondary)
+                                    .font(.system(size: 18))
+                                    .frame(width: 24, height: 24)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Select policy for bulk actions")
+                            
                             PolicyRowView(policy: pair.policy)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .background(pair.isHighlighted ? Color.white.opacity(0.12) : Color.clear)
                                 .cornerRadius(6)
-                                .padding(.leading)
+                                .padding(.leading, 4)
                                 .contentShape(Rectangle())
                             
                             NavigationLink(destination: PolicyDetailView(server: server, policy: {
@@ -351,71 +375,42 @@ struct PolicySearchView: View {
                 .padding(.vertical)
             }
             
-            
-            
-            // ################################################################################
-            //                       Print Matching IDs
-            // ################################################################################
-            
-            
-            // Button to run an operation on all matching items (prints their jamf IDs)
-//            Button("Print Matching IDs") {
-//                // Recompute matches to ensure we have the latest set
-//                updateMatchingIDs()
-//                // Print the IDs (and paired names for convenience)
-//                let ids = policiesMatchingItems
-//                let names = matchedPolicyPairsState.map { $0.policy.general?.name ?? "(no name)" }
-//                print("Matching policy jamf IDs: \(ids)")
-//                print("Matching policy names: \(names)")
-//            }
-     
-            
-            
-//#if os(macOS)
-//            List(networkController.allIconsDetailed, id: \.self, selection: $selectedIcon) { icon in
-//                HStack {
-//                    Image(systemName: "photo.circle")
-//                    Text(icon.name).font(.system(size: 12.0)).foregroundColor(.black)
-//                    AsyncImage(url: URL(string: icon.url )) { image in
-//                        image.resizable().frame(width: 15, height: 15)
-//                    } placeholder: {
-//                    }
-//                }
-//                .foregroundColor(.gray)
-//                .listRowBackground(selectedIconString == icon.name
-//                                   ? Color.green.opacity(0.3)
-//                                   : Color.clear)
-//                .tag(icon)
-//            }
-//            .cornerRadius(8)
-//            .frame(minWidth: 300, maxWidth: .infinity, maxHeight: 200, alignment: .leading)
-//#else
-//
-//            List(networkController.allIconsDetailed, id: \.self) { icon in
-//                HStack {
-//                    Image(systemName: "photo.circle")
-//                    Text(icon.name).font(.system(size: 12.0)).foregroundColor(.black)
-//                    AsyncImage(url: URL(string: icon.url )) { image in
-//                        image.resizable().frame(width: 15, height: 15)
-//                    } placeholder: {
-//                    }
-//                }
-//            }
-//#endif
-            //                                    .background(.gray)
-            //        }
-            
-            
-            DisclosureGroup("Icons") {
-                
-                
-                // ################################################################################
-                //                        Icons - picker
-                // ################################################################################
-                
+            // Actions Panel
+            if !selectedPoliciesForActions.isEmpty {
+                Divider()
+                    .padding(.vertical, 4)
                 
                 HStack {
+                    Text("Actions: \(selectedPoliciesForActions.compactMap { $0 }.count) selected")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
                     
+                    Spacer()
+                    
+                    Button(action: { selectedPoliciesForActions.removeAll() }) {
+                        Text("Clear")
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                    
+                    Button(action: { showActionsPanel.toggle() }) {
+                        HStack(spacing: 4) {
+                            Image(systemName: showActionsPanel ? "chevron.up" : "chevron.down")
+                            Text(showActionsPanel ? "Hide" : "Show")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                }
+                .padding(.vertical, 6)
+                
+                if showActionsPanel {
+                    PolicyDetailGeneralTabView(server: server, selectedPoliciesInt: Array(selectedPoliciesForActions), policiesSelection: $policiesSelection)
+                        .frame(maxHeight: 500)
+                }
+            }
+            
+            DisclosureGroup("Icons") {
+                HStack {
                     ScrollView(.horizontal, showsIndicators: true) {
                         HStack(spacing: 8) {
                             ForEach(networkController.allIconsDetailed.filter { iconFilter.isEmpty ? true : $0.name.lowercased().contains(iconFilter.lowercased()) }) { icon in
@@ -454,14 +449,6 @@ struct PolicySearchView: View {
                         }
                 }
                 
-                
-                //                ############################################################
-                //                Update Icon Button
-                //                ############################################################
-                
-                
-                
-                
                 HStack {
                     Button(action: {
                         progress.showProgress()
@@ -481,22 +468,14 @@ struct PolicySearchView: View {
                     Button(action: {
                         progress.showProgress()
                         progress.waitForABit()
-                        networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)                        }) {
-                            Text("Refresh Icons")
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.blue)
+                        networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 20000)
+                    }) {
+                        Text("Refresh Icons")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.blue)
                 }
             }
-            
-            
-            //  ##########################################################################
-            //  Progress view via showProgress
-            //  ##########################################################################
-            
-            //  ##########################################################################
-            //  Progress view via showProgress
-            //  ##########################################################################
             
             Group {
                 if progress.showProgressView == true {

--- a/Man1fest0/Views/Structures/IconsView.swift
+++ b/Man1fest0/Views/Structures/IconsView.swift
@@ -156,7 +156,6 @@ struct  IconsView: View {
             .frame(width: 400, height: 50)
             .onAppear() {
                 if networkController.allIconsDetailed.count <= 1 {
-
                     print("getAllIconsDetailed is:\(networkController.allIconsDetailed.count) - running")
                     networkController.getAllIconsDetailed(server: server, authToken: networkController.authToken, loopTotal: 5000)
                 } else {


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the policy management UI, focusing on improved bulk actions, better state management, and additional policy information display. Below are the most important changes grouped by theme:

### Bulk Actions and Selection Improvements

* Added checkboxes to `PolicySearchView` for selecting multiple policies, enabling bulk actions such as updating icons for all selected policies. An actions panel appears when policies are selected, allowing users to clear or hide the panel and perform batch operations. (`Man1fest0/Views/Policy/PolicySearchView.swift`) [[1]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20R117-R118) [[2]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20R336-R357) [[3]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20L354-L496)
* Automatically selects all matching policies after a search for convenience in bulk operations. (`Man1fest0/Views/Policy/PolicySearchView.swift`)

### UI/UX Enhancements

* Added a `DisclosureGroup` for the icons section in `PolicyDetailGeneralTabView`, making the UI more organized and allowing users to expand/collapse icon-related controls. (`Man1fest0/Views/Policy/PolicyDetailGeneralTabView.swift`) [[1]](diffhunk://#diff-72f609aa847a33338eee85f670dfdfa5216a475fa323342c62c4a5dac783b1b8R186-R187) [[2]](diffhunk://#diff-72f609aa847a33338eee85f670dfdfa5216a475fa323342c62c4a5dac783b1b8R252-R253) [[3]](diffhunk://#diff-72f609aa847a33338eee85f670dfdfa5216a475fa323342c62c4a5dac783b1b8R289)
* Simplified the match mode and case sensitivity controls in the search view for better clarity. (`Man1fest0/Views/Policy/PolicySearchView.swift`) [[1]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20L241-R248) [[2]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20L251-R258)

### Policy Information Display

* Displayed the custom trigger value in `PolicyRowView` if present, making it easier to see trigger information directly in the policy list. (`Man1fest0/Views/Policy/PolicyRowView.swift`) [[1]](diffhunk://#diff-f7e4ceb49cf72ffdd155aaf122791560b34fc0c1481ff16ec8858200436cd6e8R24) [[2]](diffhunk://#diff-f7e4ceb49cf72ffdd155aaf122791560b34fc0c1481ff16ec8858200436cd6e8R58-L58)
* Added `customTrigger` as a searchable field in the policy search, making it possible to filter policies by their custom trigger value. (`Man1fest0/Views/Policy/PolicySearchView.swift`) [[1]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20R542) [[2]](diffhunk://#diff-007ee9ee430d9fbc55fbe421cbc41fced9569365d901bddb0b5fb66daebd9b20R566)

### State Management Refactor

* Refactored the `XmlBrain` controller to use `@Published` instead of `@State` for observable properties, improving reactivity and aligning with SwiftUI best practices. (`Man1fest0/Controller/XmlBrain.swift`) [[1]](diffhunk://#diff-e4dd9a7d5aef309cb9085943ec480f7bc6e5e90f73c85bec0a29e02f19dec171L34-R42) [[2]](diffhunk://#diff-e4dd9a7d5aef309cb9085943ec480f7bc6e5e90f73c85bec0a29e02f19dec171L70-R83)

### Miscellaneous

* Updated project version in `project.pbxproj` from `1.76.2` to `1.77.2`. (`Man1fest0.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-fa19659d6eb66a0b98af00e6742f9cff8c31e6b2b3b237f8419a7e4e7d755fc4L927-R927) [[2]](diffhunk://#diff-fa19659d6eb66a0b98af00e6742f9cff8c31e6b2b3b237f8419a7e4e7d755fc4L974-R974)
* Minor bug fix to ensure `currentPolicyAsXML` is updated on the main thread after a policy XML is loaded. (`Man1fest0/Controller/XmlBrain.swift`)

These changes collectively enhance the user experience for managing policies, especially for bulk operations and searching/filtering capabilities.